### PR TITLE
Add implicit function calling

### DIFF
--- a/AtFunctions.rb
+++ b/AtFunctions.rb
@@ -5614,6 +5614,13 @@ module AtFunctionCatalog
                 raise AttacheUnimplementedError.new("a!b is not defined for non-functional arguments", inst.position)
             end
         },
+        "!!" => lambda { |inst, a, b|
+            if AtState.func_like? a
+                a[inst, b]
+            else
+                raise AttacheUnimplementedError.new("a!!b is not defined for non-functional arguments", inst.position)
+            end
+        },
     }
 
     @@unary_operators = {

--- a/AtState.rb
+++ b/AtState.rb
@@ -56,9 +56,10 @@ class AtParser
 
         return if type == :comment
 
-        if raw == "{" && @last_token.type == :word
+        if raw == "{" && [:word, :bracket_close, :func_end, :paren_close].include?(@last_token.type)
             ## call func
-            @consume_queue << Token.new("!", :operator)
+            p [ent, ent.position]
+            @consume_queue << Token.new("!!", :operator)
             @consume_queue << ent
             return
         end
@@ -154,7 +155,7 @@ class AtParser
                     if top_type == :unary_operator
                         top_prec = $PRECEDENCE_UNARY[top_raw]
                     end
-
+                    
                     break if top_assoc == :right ? top_prec <= cur_prec : top_prec < cur_prec
                     @out.push @stack.pop
                 }

--- a/AtState.rb
+++ b/AtState.rb
@@ -22,6 +22,25 @@ FormatStringInformation = Struct.new(:token, :count) {
         "FSI(#{token}, #{count})"
     end
 }
+
+class AtParser
+    def initialize(code)
+        @stack = []
+        @out = []
+        @arities = []
+        @curry_mask = []
+        @last_token = Token.new nil, nil, nil
+        @parens = []
+        @format_string_stack = []
+        @code = code
+        @source = tokenize @code
+    end
+    
+    def next
+        
+    end
+end
+
 def parse(code)
     # group expression
     stack = []
@@ -36,226 +55,6 @@ def parse(code)
 
     # di "tokenizer"
     tokenize(code).each { |ent|
-        raw, type, start = ent
-
-        next if type == :comment
-
-        # cls
-        # dh "current", ent
-        # darr "stack", stack
-        # darr "out", out
-        # darr "format", format_string_stack
-        # STDIN.gets
-
-        if type == :format_string_begin
-            format_string_stack.push FormatStringInformation.new(ent, 1)
-            stack.push Token.new(nil, :format_indicator, nil)
-            next
-
-        elsif type == :format_string_continue
-            flush(out, stack, [:format_indicator])
-            format_string_stack.last.count += 1
-            format_string_stack.last.token.raw += raw
-            next
-
-        elsif type == :format_string_end
-            format_string_stack.last.token.raw += raw
-            info = format_string_stack.pop
-            token = info.token
-            token.type = :format_string
-            flush(out, stack, [:format_indicator])
-            stack.pop
-            out << Token.new(info.count, :format_string_count, nil)
-            out << token
-            next
-
-        end
-
-        is_data = $DATA.include?(type) || open_func?(type) # || type == :curry_open
-        last_was_data = $DATA_SIGNIFIER.include? last_token.type
-
-        # two adjacent datatypes mark a statement
-        if (is_data && last_was_data || type == :statement_sep) && format_string_stack.empty?
-            flush(out, stack, [:func_start, :named_func_start])
-        end
-
-        if type == :statement_sep
-            last_token = ent
-            next
-        end
-
-        if $DATA.include? type
-            out.push ent
-
-        elsif open_func? type
-            stack.push ent
-            out.push ent
-
-        elsif type == :func_end
-            while stack.last && [:operator, :unary_operator].include?(stack.last.type)
-                out.push stack.pop
-            end
-
-            collect = []
-            until out.empty? || open_func?(out.last.type)
-                collect.unshift out.pop
-            end
-
-            if out.last.type == :named_func_start
-                #Token<"x", :word, 3>, #Token<"_", :abstract, 8>, #Token<".=", :operator, 5>
-                prefix = []
-                ["x", "y", "z"].each_with_index { |var, i|
-                    prefix.push Token.new var, :word, nil
-                    prefix.push Token.new "_#{i + 1}", :abstract, nil
-                    prefix.push Token.new ".=", :operator, nil
-                }
-                collect = prefix.concat collect
-            end
-
-            next_start = stack.pop.start
-            out.pop
-
-            out.push Token.new collect, :make_lambda, next_start
-
-        elsif type == :operator
-            if last_token.nil? || !$DATA_SIGNIFIER.include?(last_token.type)
-                ent.type = :unary_operator
-
-            else
-                cur_prec, cur_assoc = $PRECEDENCE[raw]
-                # NOTE: precedence determining
-                loop {
-                    break if stack.empty?
-                    top_raw, top_type = stack.last
-                    break if top_type != :operator && top_type != :unary_operator
-                    top_prec, top_assoc = $PRECEDENCE[top_raw]
-
-                    if top_type == :unary_operator
-                        top_prec = $PRECEDENCE_UNARY[top_raw]
-                    end
-
-                    break if top_assoc == :right ? top_prec <= cur_prec : top_prec < cur_prec
-                    out.push stack.pop
-                }
-            end
-            stack.push ent
-
-        elsif type == :bracket_open
-            if !stack.empty? && stack.last.raw == "."
-                out.push stack.pop
-            end
-
-            # determine if a function call
-            unless $SEPARATOR.include? last_token.type
-                # the "V" function creates an array
-                out.push Token.new "V", :word, nil
-            end
-            stack.push ent
-            arities.push 1
-
-        elsif type == :curry_open
-            if !stack.empty? && stack.last.raw == "."
-                out.push stack.pop
-            end
-
-            # determine if a curry call
-            unless $SEPARATOR.include? last_token.type
-                # the "Hash" function creates a hash
-                out.push Token.new "Hash", :word, nil
-                stack.push Token.new "[", :bracket_open, nil
-                curry_mask << true
-            else
-                stack.push ent
-                curry_mask << false
-            end
-            arities.push 1
-
-        elsif type == :comma
-            unless arities.last.nil?
-                arities[-1] += 1
-            end
-
-            out.push stack.pop while stack.last && [:operator, :unary_operator].include?(stack.last.type)
-
-            if arities.last.nil?
-                parens[-1] = true
-                out.push Token.new "discard", :discard, nil
-            end
-
-        elsif type == :bracket_close || (type == :curry_close && curry_mask.pop)
-            if last_token.type == :bracket_open || last_token.type == :curry_open
-                arities[-1] = 0
-            end
-
-            loop {
-                if stack.empty?
-                    raise AttacheSyntaxError.new("Unmatched closing brace: #{ent.raw}", ent.position)
-                    # STDERR.puts "Syntax Error: unmatched closing brace: #{ent}"
-                    # return nil
-                end
-                break if stack.last.type == :bracket_open
-                out.push stack.pop
-            }
-
-            out.push Token.new arities.pop, :call_func, nil
-
-            stack.pop
-
-        elsif type == :curry_close
-            if last_token.type == :curry_open
-                arities[-1] = 0
-            end
-
-            while stack.last.type != :curry_open
-                out.push stack.pop
-            end
-
-            out.push Token.new arities.pop, :curry_func, nil
-
-            stack.pop
-
-        elsif type == :paren_open
-            stack.push ent
-            # dh "stack", stack
-            # dh "out", out
-            arities.push nil
-            parens.push nil
-
-        elsif type == :paren_close
-            arities.pop
-            temp = []
-            loop {
-                if stack.empty?
-                    raise AttacheSyntaxError.new("Expected an open parenthesis to match #{raw.inspect}", ent.position)
-                end
-                break if stack.last.type == :paren_open
-                temp.push stack.pop
-            }
-            stack.pop
-
-            # if parens.pop
-                # # out.unshift Token.new "Last", :word, nil
-                # # stack.unshift Token.new "[", :bracket_open, nil
-                # # dh "stack", stack
-                # # dh "out", out
-            # else
-                # # dh "stack", stack
-                # # stack.pop
-            # end
-
-
-            # temp.unshift Token.new("Last",:word,nil) if parens.pop
-
-            out.concat temp
-
-        elsif type == :whitespace
-            # do nothing
-
-        else
-            STDERR.puts "Unknown type #{type.inspect} (#{raw.inspect}) during shunting"
-            raise
-        end
-        last_token = ent if type != :whitespace
     }
 
     flush out, stack

--- a/AtState.rb
+++ b/AtState.rb
@@ -40,6 +40,8 @@ class AtParser
     def read_token
         if @consume_queue.empty?
             @source.next
+        else
+            @consume_queue.shift
         end
     rescue StopIteration
         nil
@@ -53,6 +55,13 @@ class AtParser
         raw, type, start = ent
 
         return if type == :comment
+
+        if raw == "{" && @last_token.type == :word
+            ## call func
+            @consume_queue << Token.new("!", :operator)
+            @consume_queue << ent
+            return
+        end
 
         if type == :format_string_begin
             @format_string_stack.push FormatStringInformation.new(ent, 1)
@@ -97,14 +106,6 @@ class AtParser
         end
 
         if $DATA.include? type
-            @out.push ent
-
-        elsif raw == "{" && @last_token.type == :word
-            ## call func
-
-            p "oh"
-
-            @stack.push ent
             @out.push ent
 
         elsif open_func? type

--- a/AtState.rb
+++ b/AtState.rb
@@ -58,7 +58,6 @@ class AtParser
 
         if raw == "{" && [:word, :bracket_close, :func_end, :paren_close].include?(@last_token.type)
             ## call func
-            p [ent, ent.position]
             @consume_queue << Token.new("!!", :operator)
             @consume_queue << ent
             return

--- a/AtState.rb
+++ b/AtState.rb
@@ -46,7 +46,11 @@ class AtParser
     rescue StopIteration
         nil
     end
-
+    
+    def imp_call_start?(type)
+        [:word, :bracket_close, :func_end, :paren_close].include? type
+    end
+    
     def step
         ent = read_token
 
@@ -56,7 +60,7 @@ class AtParser
 
         return if type == :comment
 
-        if raw == "{" && [:word, :bracket_close, :func_end, :paren_close].include?(@last_token.type)
+        if raw == "{" && imp_call_start?(@last_token.type) && @last_token.line == ent.line
             ## call func
             @consume_queue << Token.new("!!", :operator)
             @consume_queue << ent

--- a/libs/std.@
+++ b/libs/std.@
@@ -368,10 +368,10 @@ MakeFunction[x, bonder] := (
 CellReplace := Curry[[cond, with, list] -> {
     cond .= MakeFunction[cond, `==]
     with .= MakeFunction[with]
-    {
-        If[cond[_],
-            with[_],
-            _
+    ${
+        If[cond[x],
+            with[x],
+            x
         ]
     } @> list
 }]

--- a/tokenize.rb
+++ b/tokenize.rb
@@ -142,6 +142,8 @@ $PRECEDENCE = {
     "▷"       => [6, :left], # |> alias
     "<|"       => [6, :right],
     "◁"       => [6, :left], # <| alias
+    
+    "!!"       => [6, :right],
 
     "and"      => [6, :left],
     "∧"        => [6, :left], # and alias

--- a/tokenize.rb
+++ b/tokenize.rb
@@ -68,114 +68,114 @@ $CURRY_CLOSE = /~>|»/
 $STATEMENT_SEP = /;/
 
 $PRECEDENCE = {
-    "."        => [999, :left],
+    "."        => [99999, :left],
 
-    ":"        => [30, :left],
-    "::"       => [30, :left],
+    ":"        => [300, :left],
+    "::"       => [300, :left],
 
-    "`"        => [28, :left],
+    "`"        => [280, :left],
 
-    "&"        => [26, :left],
-    "&:"       => [26, :left],
-    "~"        => [25, :left],
-    "@"        => [24, :left],
-    "@@"       => [24, :left],
-    "@%"       => [24, :left],
-    "&>"       => [20, :right],
-    "=>"       => [20, :right],
-    "@>"       => [20, :right],
-    "⇒"       => [20, :right], # => alias
-    "\\"       => [20, :right],
-    "#"        => [20, :left],
-    "''"       => [20, :left],
-    "'"        => [20, :left],
-    "##"       => [19, :left],
+    "&"        => [260, :left],
+    "&:"       => [260, :left],
+    "~"        => [250, :left],
+    "@"        => [240, :left],
+    "@@"       => [240, :left],
+    "@%"       => [240, :left],
+    "&>"       => [200, :right],
+    "=>"       => [200, :right],
+    "@>"       => [200, :right],
+    "⇒"       => [200, :right], # => alias
+    "\\"       => [200, :right],
+    "#"        => [200, :left],
+    "''"       => [200, :left],
+    "'"        => [200, :left],
+    "##"       => [190, :left],
 
 
 
-    "∩"        => [18, :left], # Intersection alias
-    "∪"        => [17, :left], # Union alias
-    "∆"        => [17, :left], # symmetric difference
-    "Ø"        => [17, :left], # setwise difference
-    "^^"       => [17, :left], # similar to the above
-    "⩓"        => [17, :left], # ^^ alias
+    "∩"        => [180, :left], # Intersection alias
+    "∪"        => [170, :left], # Union alias
+    "∆"        => [170, :left], # symmetric difference
+    "Ø"        => [170, :left], # setwise difference
+    "^^"       => [170, :left], # similar to the above
+    "⩓"        => [170, :left], # ^^ alias
 
-    "!"        => [16, :right],
-    "^"        => [15, :right],
-    "?"        => [15, :left],
-    "*"        => [13, :left],
-    "/"        => [13, :left],
-    "//"       => [13, :left],
-    "⁄"        => [13, :left], # // alias (fraction slash)
-    "%"        => [13, :left],
-    "|"        => [12, :left],
-    "+"        => [11, :left],
-    "-"        => [11, :left],
-    "±"        => [11, :left],
-    "<:"       => [10, :left],
-    "↞"       => [10, :left],
+    "!"        => [160, :right],
+    "^"        => [150, :right],
+    "?"        => [150, :left],
+    "*"        => [130, :left],
+    "/"        => [130, :left],
+    "//"       => [130, :left],
+    "⁄"        => [130, :left], # // alias (fraction slash)
+    "%"        => [130, :left],
+    "|"        => [120, :left],
+    "+"        => [110, :left],
+    "-"        => [110, :left],
+    "±"        => [110, :left],
+    "<:"       => [100, :left],
+    "↞"       => [100, :left],
 
-    "="        => [9, :left],
-    "=/="      => [9, :left],
-    "/="       => [9, :left],
-    "≠"        => [9, :left], # /= alias
-    "=="       => [9, :left],
-    "is"       => [9, :left], # == alias
-    "<"        => [9, :left],
-    ">"        => [9, :left],
-    "<="       => [9, :left],
-    "≤"        => [9, :left], # <= alias
-    ">="       => [9, :left],
-    "≥"        => [9, :left], # >= alias
+    "="        => [90, :left],
+    "=/="      => [90, :left],
+    "/="       => [90, :left],
+    "≠"        => [90, :left], # /= alias
+    "=="       => [90, :left],
+    "is"       => [90, :left], # == alias
+    "<"        => [90, :left],
+    ">"        => [90, :left],
+    "<="       => [90, :left],
+    "≤"        => [90, :left], # <= alias
+    ">="       => [90, :left],
+    "≥"        => [90, :left], # >= alias
 
-    "in"       => [8, :left],
-    "!in"      => [8, :left],
-    "is_a"     => [8, :left],
-    "is_an"    => [8, :left],
+    "in"       => [80, :left],
+    "!in"      => [80, :left],
+    "is_a"     => [80, :left],
+    "is_an"    => [80, :left],
 
-    ".."       => [7, :left],
-    "‥"        => [7, :left], # .. alias
-    "..."      => [7, :left],
-    "…"        => [7, :left], # ... alias
+    ".."       => [70, :left],
+    "‥"        => [70, :left], # .. alias
+    "..."      => [70, :left],
+    "…"        => [70, :left], # ... alias
 
-    "|>"       => [6, :left],
-    "▷"       => [6, :left], # |> alias
-    "<|"       => [6, :right],
-    "◁"       => [6, :left], # <| alias
+    "|>"       => [60, :left],
+    "▷"       => [60, :left], # |> alias
+    "<|"       => [60, :right],
+    "◁"       => [60, :left], # <| alias
     
-    "!!"       => [6, :right],
+    "!!"       => [60, :left],
 
-    "and"      => [6, :left],
-    "∧"        => [6, :left], # and alias
-    "nor"      => [6, :left],
-    "⊽"        => [6, :left], # nor alias
-    "not"      => [6, :left],
-    "xor"      => [5, :left],
-    "⊻"        => [5, :left], # xor alias
-    "or"       => [5, :left],
-    "∨"        => [5, :left], # or alias
-    "nand"     => [5, :left],
-    "⊼"        => [5, :left], # nand alias
+    "and"      => [60, :left],
+    "∧"        => [60, :left], # and alias
+    "nor"      => [60, :left],
+    "⊽"        => [60, :left], # nor alias
+    "not"      => [60, :left],
+    "xor"      => [50, :left],
+    "⊻"        => [50, :left], # xor alias
+    "or"       => [50, :left],
+    "∨"        => [50, :left], # or alias
+    "nand"     => [50, :left],
+    "⊼"        => [50, :left], # nand alias
 
-    "->"       => [4, :left],
-    "→"        => [4, :left], # -> alias
+    "->"       => [40, :left],
+    "→"        => [40, :left], # -> alias
 
-    "else"     => [3, :left],
-    ":>"       => [3, :left],
-    "↠"       => [3, :left], # :> alias
-    "typeof"   => [3, :left],
-    "parentof" => [3, :left],
+    "else"     => [30, :left],
+    ":>"       => [30, :left],
+    "↠"       => [30, :left], # :> alias
+    "typeof"   => [30, :left],
+    "parentof" => [30, :left],
 
-    ":="       => [2, :right],
-    "::="      => [2, :right],
-    "≔"       => [2, :right],
-    ".="       => [2, :right],
-    "..="      => [2, :right],
-    "@="       => [2, :right],
+    ":="       => [20, :right],
+    "::="      => [20, :right],
+    "≔"       => [20, :right],
+    ".="       => [20, :right],
+    "..="      => [20, :right],
+    "@="       => [20, :right],
 
-    ";;"       => [1, :left],
+    ";;"       => [10, :left],
 }
-$PRECEDENCE_UNARY = Hash.new(99)
+$PRECEDENCE_UNARY = Hash.new(999)
 $PRECEDENCE_UNARY["..."] = 0
 $PRECEDENCE_UNARY["…"] = 0
 

--- a/tokenize.rb
+++ b/tokenize.rb
@@ -138,18 +138,18 @@ $PRECEDENCE = {
     "..."      => [70, :left],
     "…"        => [70, :left], # ... alias
 
-    "|>"       => [60, :left],
-    "▷"       => [60, :left], # |> alias
-    "<|"       => [60, :right],
-    "◁"       => [60, :left], # <| alias
+    "|>"       => [65, :left],
+    "▷"       => [65, :left], # |> alias
+    "<|"       => [65, :right],
+    "◁"       => [65, :left], # <| alias
     
     "!!"       => [60, :left],
 
-    "and"      => [60, :left],
-    "∧"        => [60, :left], # and alias
-    "nor"      => [60, :left],
-    "⊽"        => [60, :left], # nor alias
-    "not"      => [60, :left],
+    "and"      => [55, :left],
+    "∧"        => [55, :left], # and alias
+    "nor"      => [55, :left],
+    "⊽"        => [55, :left], # nor alias
+    "not"      => [55, :left],
     "xor"      => [50, :left],
     "⊻"        => [50, :left], # xor alias
     "or"       => [50, :left],


### PR DESCRIPTION
This syntax interprets `word` followed by `{ ... }` to be equivalent to `word !! { ... }`, that is, `word[{ ... }]`. This allows for some more natural constructs than previous:

```
Class[{
    name .= _1
    age .= _2
}]
```

becomes 

```
Class {
    name .= _1
    age .= _2
}
```

And we can write `Fold { (_1 + _2) / 2 }` instead of `Fold[{ (_1 + _2) / 2 }]`.

Note that the following are not equivalent:

```
Map { _ + 1 }
```

```
Map
{ _ + 1 }
```

Here, the newline separates these types of statements.

## Another example

```
ClassNamed[Person] {
    name ' age .= __
    
    $string[] .= $"${name}, age ${age}"
}

Print[Person["Timothy", 32]]
?? Timothy, age 32
```